### PR TITLE
Fixes #60: Add 'git-cz' entrypoint in user's PATH.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ isort = "^4.3.21"
 
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"
+git-cz = "commitizen.cli:main"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Project can now be invoked as 'git cz'.