### PR TITLE
Fixes #56: feat(Commands/commit): add ´--dry-run´ flag to the Commit command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -45,7 +45,12 @@ data = {
                         "name": ["--retry"],
                         "action": "store_true",
                         "help": "retry last commit",
-                    }
+                    },
+                    {
+                        "name": "--dry-run",
+                        "action": "store_true",
+                        "help": "show output to stdout, no commit, no modified files",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -63,6 +63,12 @@ class Commit:
             m = self.prompt_commit_questions()
 
         out.info(f"\n{m}\n")
+
+        dry_run: bool = self.arguments.get("dry_run")
+
+        if dry_run:
+            raise SystemExit(NOTHING_TO_COMMIT)
+
         c = git.commit(m)
 
         if c.err:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,6 +82,23 @@ def test_commit_retry_works(mocker):
     assert not os.path.isfile(temp_file)
 
 
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_dry_run_option(mocker):
+    prompt_mock = mocker = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "closes #57",
+        "footer": "",
+    }
+
+    with pytest.raises(SystemExit):
+        commit_cmd = commands.Commit(config, {"dry_run": True})
+        commit_cmd()
+
+
 def test_commit_when_nothing_to_commit(mocker):
     is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
     is_staging_clean_mock.return_value = True


### PR DESCRIPTION
Generate a commit message without doing anything

closes #56