### PR TITLE
fix(commands/check.py): make --commit-msg-file a required argument for check command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -7,7 +7,6 @@ from decli import cli
 
 from commitizen import commands, config, out
 
-
 logger = logging.getLogger(__name__)
 data = {
     "prog": "cz",

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -118,6 +118,7 @@ data = {
                 "arguments": [
                     {
                         "name": "--commit-msg-file",
+                        "required": True,
                         "help": (
                             "ask for the name of the temporal file that contains "
                             "the commit message. "

--- a/commitizen/commands/__init__.py
+++ b/commitizen/commands/__init__.py
@@ -1,11 +1,10 @@
 from .bump import Bump
-from .commit import Commit
 from .check import Check
+from .commit import Commit
 from .example import Example
 from .info import Info
 from .list_cz import ListCz
 from .schema import Schema
 from .version import Version
 
-__all__ = ("Bump", "Check", "Commit", "Example", "Info", "ListCz", "Schema",
-           "Version")
+__all__ = ("Bump", "Check", "Commit", "Example", "Info", "ListCz", "Schema", "Version")

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -3,8 +3,10 @@ import re
 
 from commitizen import out
 
-PATTERN = (r'(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)'
-           r'(\([\w\-]+\))?:\s.*')
+PATTERN = (
+    r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)"
+    r"(\([\w\-]+\))?:\s.*"
+)
 NO_COMMIT_MSG = 3
 INVALID_COMMIT_MSG = 5
 
@@ -46,7 +48,7 @@ class Check:
 
     def _get_commit_msg(self):
         temp_filename: str = self.arguments.get("commit_msg_file")
-        return open(temp_filename, 'r').read()
+        return open(temp_filename, "r").read()
 
     def _is_conventional(self, pattern, commit_msg):
         return re.match(PATTERN, commit_msg)

--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -2,8 +2,8 @@ import importlib
 import pkgutil
 
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
-from commitizen.cz.jira import JiraSmartCz
 from commitizen.cz.customize import CustomizeCommitsCz
+from commitizen.cz.jira import JiraSmartCz
 
 registry = {
     "cz_conventional_commits": ConventionalCommitsCz,

--- a/tests/test_bump_command.py
+++ b/tests/test_bump_command.py
@@ -1,7 +1,7 @@
+import errno
 import os
 import shutil
 import stat
-import errno
 import sys
 import uuid
 from pathlib import Path

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -179,12 +179,11 @@ def test_check_no_conventional_commit(mocker):
         with get_temp_dir() as dir:
 
             tempfile = os.path.join(dir, "temp_commit_file")
-            with open(tempfile, 'w') as f:
+            with open(tempfile, "w") as f:
                 f.write("no conventional commit")
 
             check_cmd = commands.Check(
-                config=config,
-                arguments={"commit_msg_file": tempfile}
+                config=config, arguments={"commit_msg_file": tempfile}
             )
             check_cmd()
             error_mock.assert_called_once()
@@ -195,12 +194,11 @@ def test_check_conventional_commit(mocker):
     with get_temp_dir() as dir:
 
         tempfile = os.path.join(dir, "temp_commit_file")
-        with open(tempfile, 'w') as f:
+        with open(tempfile, "w") as f:
             f.write("feat(lang): added polish language")
 
         check_cmd = commands.Check(
-            config=config,
-            arguments={"commit_msg_file": tempfile}
+            config=config, arguments={"commit_msg_file": tempfile}
         )
 
         check_cmd()
@@ -209,7 +207,4 @@ def test_check_conventional_commit(mocker):
 
 def test_check_command_when_commit_file_not_found():
     with pytest.raises(FileNotFoundError):
-        commands.Check(
-            config=config,
-            arguments={"commit_msg_file": ""}
-        )()
+        commands.Check(config=config, arguments={"commit_msg_file": ""})()

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -1,8 +1,8 @@
 import pytest
 from tomlkit import parse
 
-from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.config import Config
+from commitizen.cz.customize import CustomizeCommitsCz
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Currently, if --commit-msg-file is not provided, it throws exception