### PR TITLE
Rename files to version files

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -81,7 +81,7 @@ class Bump:
         current_tag_version: str = bump.create_tag(
             current_version, tag_format=tag_format
         )
-        files: list = self.parameters["files"]
+        version_files: list = self.parameters["version_files"]
         dry_run: bool = self.parameters["dry_run"]
 
         is_yes: bool = self.arguments["yes"]
@@ -124,7 +124,7 @@ class Bump:
         if dry_run:
             raise SystemExit()
 
-        bump.update_version_in_files(current_version, new_version.public, files)
+        bump.update_version_in_files(current_version, new_version.public, version_files)
         if is_files_only:
             raise SystemExit()
 

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 
 from commitizen.defaults import DEFAULT_SETTINGS
@@ -32,3 +33,16 @@ class BaseConfig:
 
     def _parse_setting(self, data: str) -> dict:
         raise NotImplementedError()
+
+    # TODO: remove "files" supported in 2.0
+    @classmethod
+    def _show_files_column_deprecated_warning(cls):
+        warnings.simplefilter("always", DeprecationWarning)
+        warnings.warn(
+            (
+                '"files" is renamed as "version_files" '
+                "and will be deprecated in next major version\n"
+                'Please repalce "files" with "version_files"'
+            ),
+            category=DeprecationWarning,
+        )

--- a/commitizen/config/ini_config.py
+++ b/commitizen/config/ini_config.py
@@ -56,13 +56,14 @@ class IniConfig(BaseConfig):
         try:
             _data: dict = dict(config["commitizen"])
             if "files" in _data:
-                files = _data["files"]
-                _f = json.loads(files)
-                _data.update({"files": _f})
+                IniConfig._show_files_column_deprecated_warning()
+                _data.update({"version_files": json.loads(_data["files"])})
+
+            if "version_files" in _data:
+                _data.update({"version_files": json.loads(_data["version_files"])})
+
             if "style" in _data:
-                style = _data["style"]
-                _s = json.loads(style)
-                _data.update({"style": _s})
+                _data.update({"style": json.loads(_data["style"])})
 
             self._settings.update(_data)
         except KeyError:

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -37,3 +37,7 @@ class TomlConfig(BaseConfig):
             self.settings.update(doc["tool"]["commitizen"])
         except exceptions.NonExistentKey:
             self.is_empty_config = True
+
+        if "files" in self.settings:
+            self.settings["version_files"] = self.settings["files"]
+            TomlConfig._show_files_column_deprecated_warning

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -2,11 +2,10 @@ name: str = "cz_conventional_commits"
 # TODO: .cz, setup.cfg, .cz.cfg should be removed in 2.0
 config_files: list = ["pyproject.toml", ".cz.toml", ".cz", "setup.cfg", ".cz.cfg"]
 
-
 DEFAULT_SETTINGS = {
     "name": "cz_conventional_commits",
     "version": None,
-    "files": [],
+    "version_files": [],
     "tag_format": None,  # example v$version
     "bump_message": None,  # bumped v$current_version to $new_version
 }

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,7 +8,7 @@ PYPROJECT = """
 [tool.commitizen]
 name = "cz_jira"
 version = "1.0.0"
-files = [
+version_files = [
     "commitizen/__version__.py",
     "pyproject.toml"
 ]
@@ -26,7 +26,7 @@ RAW_CONFIG = """
 [commitizen]
 name = cz_jira
 version = 1.0.0
-files = [
+version_files = [
     "commitizen/__version__.py",
     "pyproject.toml"
     ]
@@ -41,7 +41,7 @@ _settings = {
     "version": "1.0.0",
     "tag_format": None,
     "bump_message": None,
-    "files": ["commitizen/__version__.py", "pyproject.toml"],
+    "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
 }
 
@@ -50,14 +50,14 @@ _new_settings = {
     "version": "2.0.0",
     "tag_format": None,
     "bump_message": None,
-    "files": ["commitizen/__version__.py", "pyproject.toml"],
+    "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
 }
 
 _read_settings = {
     "name": "cz_jira",
     "version": "1.0.0",
-    "files": ["commitizen/__version__.py", "pyproject.toml"],
+    "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
 }
 


### PR DESCRIPTION
This PR is based #100 and should be reviewed after #100 is merged.

Related Issue: #82

* Use "version_files" internally, but users can still use "files" till the next release.