### PR TITLE
fix(github_action/pythonpackage): separate run test into 3 steps

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,13 @@ jobs:
         poetry install
     - name: Run tests
       run: |
-        ./scripts/test
+        poetry run pytest --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/
+    - name: Run black style check
+      run: |
+        poetry run black commitizen tests --check
+    - name: Run flake8 style check
+      run: |
+        poetry run flake8 --max-line-length=88 commitizen/ tests/
     - name: Upload coverage to Codecov
       if: runner.os == 'Linux'
       uses: codecov/codecov-action@v1.0.3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,6 +24,8 @@ jobs:
         poetry install
     - name: Run tests
       run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
         poetry run pytest --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/
     - name: Run black style check
       run: |


### PR DESCRIPTION
This PR is based #100 and should be reviewed after #100 is merged.
There is an error hard to fix in the original design but is fixed in the "refactor-config" new design.

without separating, the pipeline will continue when the third step succeeded even if the first two steps failed

#106