### PR TITLE
ci(scripts/publish): remove github_token check

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -1,7 +1,2 @@
 # Publish to pypi
 poetry publish --build -u $PYPI_USERNAME -p $PYPI_PASSWORD
-
-[ -z "${GITHUB_TOKEN}" ] && {
-    echo 'Missing input "github_token: ${{ secrets.GITHUB_TOKEN }}".';
-    exit 1;
-};


### PR DESCRIPTION
it's no longer needed due to the removal of mkdocs

#119 