### PR TITLE
Refactor

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -17,7 +17,7 @@ from commitizen.defaults import (
 
 
 def find_increment(
-    messages: List[str], regex: str = bump_pattern, increments_map: dict = bump_map
+    commits: List[str], regex: str = bump_pattern, increments_map: dict = bump_map
 ) -> Optional[str]:
 
     # Most important cases are major and minor.
@@ -26,18 +26,19 @@ def find_increment(
     pattern = re.compile(regex)
     increment = None
 
-    for message in messages:
-        result = pattern.search(message)
-        if not result:
-            continue
-        found_keyword = result.group(0)
-        new_increment = increments_map_default[found_keyword]
-        if new_increment == "MAJOR":
+    for commit in commits:
+        for message in commit.split("\n"):
+            result = pattern.search(message)
+            if not result:
+                continue
+            found_keyword = result.group(0)
+            new_increment = increments_map_default[found_keyword]
+            if new_increment == "MAJOR":
+                increment = new_increment
+                break
+            elif increment == "MINOR" and new_increment == "PATCH":
+                continue
             increment = new_increment
-            break
-        elif increment == "MINOR" and new_increment == "PATCH":
-            continue
-        increment = new_increment
 
     return increment
 

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 
 from packaging.version import Version
 
+from commitizen.git import GitCommit
 from commitizen.defaults import (
     MAJOR,
     MINOR,
@@ -17,7 +18,7 @@ from commitizen.defaults import (
 
 
 def find_increment(
-    commits: List[str], regex: str = bump_pattern, increments_map: dict = bump_map
+    commits: List[GitCommit], regex: str = bump_pattern, increments_map: dict = bump_map
 ) -> Optional[str]:
 
     # Most important cases are major and minor.
@@ -27,7 +28,7 @@ def find_increment(
     increment = None
 
     for commit in commits:
-        for message in commit.split("\n"):
+        for message in commit.message.split("\n"):
             result = pattern.search(message)
             if not result:
                 continue

--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -10,9 +10,12 @@ class Command(NamedTuple):
 
 
 def run(cmd: str) -> Command:
-    cmd.split()
     process = subprocess.Popen(
-        cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
     )
     stdout, stderr = process.communicate()
     return Command(stdout.decode(), stderr.decode(), stdout, stderr)

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import questionary
 from packaging.version import Version
@@ -54,7 +54,7 @@ class Bump:
                 is_initial = questionary.confirm("Is this the first tag created?").ask()
         return is_initial
 
-    def find_increment(self, commits: list) -> Optional[str]:
+    def find_increment(self, commits: List[git.GitCommit]) -> Optional[str]:
         bump_pattern = self.cz.bump_pattern
         bump_map = self.cz.bump_map
         if not bump_map or not bump_pattern:
@@ -93,7 +93,10 @@ class Bump:
         is_files_only: Optional[bool] = self.arguments["files_only"]
 
         is_initial = self.is_initial_tag(current_tag_version, is_yes)
-        commits = git.get_commits(current_tag_version, from_beginning=is_initial)
+        if is_initial:
+            commits = git.get_commits()
+        else:
+            commits = git.get_commits(current_tag_version)
 
         # No commits, there is no need to create an empty tag.
         # Unless we previously had a prerelease.

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -5,7 +5,7 @@ import questionary
 from commitizen import factory, out
 from commitizen.cz import registry
 from commitizen.config import BaseConfig, TomlConfig, IniConfig
-from commitizen.git import get_latest_tag, get_all_tags
+from commitizen.git import get_latest_tag_name, get_tag_names
 from commitizen.defaults import config_files
 
 
@@ -57,7 +57,7 @@ class Init:
         return name
 
     def _ask_tag(self) -> str:
-        latest_tag = get_latest_tag()
+        latest_tag = get_latest_tag_name()
         if not latest_tag:
             out.error("No Existing Tag. Set tag to v0.0.1")
             return "0.0.1"
@@ -66,14 +66,14 @@ class Init:
             f"Is {latest_tag} the latest tag?", style=self.cz.style, default=False
         ).ask()
         if not is_correct_tag:
-            tags = get_all_tags()
+            tags = get_tag_names()
             if not tags:
                 out.error("No Existing Tag. Set tag to v0.0.1")
                 return "0.0.1"
 
             latest_tag = questionary.select(
                 "Please choose the latest tag: ",
-                choices=get_all_tags(),
+                choices=get_tag_names(),
                 style=self.cz.style,
             ).ask()
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -20,9 +20,14 @@ def commit(message: str, args=""):
     return c
 
 
-def get_commits(start: str, end: str = "HEAD", from_beginning: bool = False) -> list:
+def get_commits(
+    start: str,
+    end: str = "HEAD",
+    *,
+    from_beginning: bool = False,
+    log_format: str = "%s%n%b",
+) -> list:
     delimiter = '"----------commit-delimiter----------"'
-    log_format = "%s%n%b"
     git_log_cmd = f"git log --pretty={log_format}{delimiter}"
 
     c = cmd.run(f"{git_log_cmd} {start}...{end}")
@@ -32,7 +37,7 @@ def get_commits(start: str, end: str = "HEAD", from_beginning: bool = False) -> 
 
     if not c.out:
         return []
-    return [commit.strip() for commit in c.out.split(delimiter) if commit]
+    return [commit.strip() for commit in c.out.split(delimiter) if commit.strip()]
 
 
 def tag_exist(tag: str) -> bool:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -20,13 +20,24 @@ def commit(message: str, args=""):
     return c
 
 
+def get_first_commit() -> str:
+    c = cmd.run("git rev-list --max-parents=0 HEAD")
+    return c.out.strip()
+
+
 def get_commits(
-    start: str,
+    start: Optional[str] = None,
     end: str = "HEAD",
     *,
     from_beginning: bool = False,
     log_format: str = "%s%n%b",
 ) -> list:
+    """
+    Get the commits betweeen start and end (incldue end but not start)
+    """
+    if not start:
+        start = get_first_commit()
+
     delimiter = '"----------commit-delimiter----------"'
     git_log_cmd = f"git log --pretty={log_format}{delimiter}"
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -21,15 +21,18 @@ def commit(message: str, args=""):
 
 
 def get_commits(start: str, end: str = "HEAD", from_beginning: bool = False) -> list:
+    delimiter = '"----------commit-delimiter----------"'
+    log_format = "%s%n%b"
+    git_log_cmd = f"git log --pretty={log_format}{delimiter}"
 
-    c = cmd.run(f"git log --pretty=format:%s%n%b {start}...{end}")
+    c = cmd.run(f"{git_log_cmd} {start}...{end}")
 
     if from_beginning:
-        c = cmd.run(f"git log --pretty=format:%s%n%b {end}")
+        c = cmd.run(f"{git_log_cmd} {end}")
 
     if not c.out:
         return []
-    return c.out.split("\n")
+    return [commit.strip() for commit in c.out.split(delimiter) if commit]
 
 
 def tag_exist(tag: str) -> bool:

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -106,6 +106,7 @@ def test_bump_is_not_specify(mocker, capsys, tmpdir):
 
     with pytest.raises(SystemExit):
         with tmpdir.as_cwd():
+            cmd.run("git init")
             cli.main()
 
     expected_error_message = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from commitizen import cmd
+
+
+@pytest.fixture(scope="function")
+def tmp_git_project(tmpdir):
+    with tmpdir.as_cwd():
+        cmd.run("git init")
+
+        yield
+
+
+@pytest.fixture(scope="function")
+@pytest.mark.usefixtures("tmp_git_project")
+def tmp_commitizen_project(tmp_git_project):
+    with open("pyproject.toml", "w") as f:
+        f.write("[tool.commitizen]\n" 'version="0.1.0"')

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -3,6 +3,7 @@ CC: Conventional commits
 SVE: Semantic version at the end
 """
 from commitizen import bump
+from commitizen.git import GitCommit
 
 NONE_INCREMENT_CC = ["docs(README): motivation", "ci: added travis"]
 
@@ -45,49 +46,56 @@ semantic_version_map = {"MAJOR": "MAJOR", "MINOR": "MINOR", "PATCH": "PATCH"}
 
 def test_find_increment_type_patch():
     messages = PATCH_INCREMENTS_CC
-    increment_type = bump.find_increment(messages)
+    commits = [GitCommit(rev="test", title=message) for message in messages]
+    increment_type = bump.find_increment(commits)
     assert increment_type == "PATCH"
 
 
 def test_find_increment_type_minor():
     messages = MINOR_INCREMENTS_CC
-    increment_type = bump.find_increment(messages)
+    commits = [GitCommit(rev="test", title=message) for message in messages]
+    increment_type = bump.find_increment(commits)
     assert increment_type == "MINOR"
 
 
 def test_find_increment_type_major():
     messages = MAJOR_INCREMENTS_CC
-    increment_type = bump.find_increment(messages)
+    commits = [GitCommit(rev="test", title=message) for message in messages]
+    increment_type = bump.find_increment(commits)
     assert increment_type == "MAJOR"
 
 
 def test_find_increment_type_patch_sve():
     messages = PATCH_INCREMENTS_SVE
+    commits = [GitCommit(rev="test", title=message) for message in messages]
     increment_type = bump.find_increment(
-        messages, regex=semantic_version_pattern, increments_map=semantic_version_map
+        commits, regex=semantic_version_pattern, increments_map=semantic_version_map
     )
     assert increment_type == "PATCH"
 
 
 def test_find_increment_type_minor_sve():
     messages = MINOR_INCREMENTS_SVE
+    commits = [GitCommit(rev="test", title=message) for message in messages]
     increment_type = bump.find_increment(
-        messages, regex=semantic_version_pattern, increments_map=semantic_version_map
+        commits, regex=semantic_version_pattern, increments_map=semantic_version_map
     )
     assert increment_type == "MINOR"
 
 
 def test_find_increment_type_major_sve():
     messages = MAJOR_INCREMENTS_SVE
+    commits = [GitCommit(rev="test", title=message) for message in messages]
     increment_type = bump.find_increment(
-        messages, regex=semantic_version_pattern, increments_map=semantic_version_map
+        commits, regex=semantic_version_pattern, increments_map=semantic_version_map
     )
     assert increment_type == "MAJOR"
 
 
 def test_find_increment_type_none():
     messages = NONE_INCREMENT_CC
+    commits = [GitCommit(rev="test", title=message) for message in messages]
     increment_type = bump.find_increment(
-        messages, regex=semantic_version_pattern, increments_map=semantic_version_map
+        commits, regex=semantic_version_pattern, increments_map=semantic_version_map
     )
     assert increment_type is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,19 +2,8 @@ import sys
 
 import pytest
 
-from commitizen import cli, cmd
+from commitizen import cli
 from commitizen.__version__ import __version__
-
-
-@pytest.fixture(scope="function")
-def tmp_git_project(tmpdir):
-    with tmpdir.as_cwd():
-        with open("pyproject.toml", "w") as f:
-            f.write("[tool.commitizen]\n" 'version="0.1.0"')
-
-        cmd.run("git init")
-
-        yield
 
 
 def test_sysexit_no_argv(mocker, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,19 @@ import sys
 
 import pytest
 
-from commitizen import cli
+from commitizen import cli, cmd
 from commitizen.__version__ import __version__
+
+
+@pytest.fixture(scope="function")
+def tmp_git_project(tmpdir):
+    with tmpdir.as_cwd():
+        with open("pyproject.toml", "w") as f:
+            f.write("[tool.commitizen]\n" 'version="0.1.0"')
+
+        cmd.run("git init")
+
+        yield
 
 
 def test_sysexit_no_argv(mocker, capsys):
@@ -35,14 +46,14 @@ def test_name(mocker, capsys):
     assert out.startswith("JRA")
 
 
-def test_name_default_value(tmpdir, mocker, capsys):
-    with tmpdir.as_cwd() as _:
-        testargs = ["cz", "example"]
-        mocker.patch.object(sys, "argv", testargs)
+@pytest.mark.usefixtures("tmp_git_project")
+def test_name_default_value(mocker, capsys):
+    testargs = ["cz", "example"]
+    mocker.patch.object(sys, "argv", testargs)
 
-        cli.main()
-        out, _ = capsys.readouterr()
-        assert out.startswith("fix: correct minor typos in code")
+    cli.main()
+    out, _ = capsys.readouterr()
+    assert out.startswith("fix: correct minor typos in code")
 
 
 def test_ls(mocker, capsys):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,6 +1,12 @@
 from commitizen import git
 
 
+class FakeCommand:
+    def __init__(self, out=None, err=None):
+        self.out = out
+        self.err = err
+
+
 def test_git_object_eq():
     git_commit = git.GitCommit(
         rev="sha1-code", title="this is title", body="this is body"
@@ -9,3 +15,35 @@ def test_git_object_eq():
 
     assert git_commit == git_tag
     assert git_commit != "sha1-code"
+
+
+def test_get_tags(mocker):
+    tag_str = (
+        "v1.0.0---inner_delimiter---333---inner_delimiter---2020-01-20\n"
+        "v0.5.0---inner_delimiter---222---inner_delimiter---2020-01-17\n"
+        "v0.0.1---inner_delimiter---111---inner_delimiter---2020-01-17\n"
+    )
+    mocker.patch("commitizen.cmd.run", return_value=FakeCommand(out=tag_str))
+
+    git_tags = git.get_tags()
+    latest_git_tag = git_tags[0]
+    assert latest_git_tag.rev == "333"
+    assert latest_git_tag.name == "v1.0.0"
+    assert latest_git_tag.date == "2020-01-20"
+
+    mocker.patch(
+        "commitizen.cmd.run", return_value=FakeCommand(out="", err="No tag available")
+    )
+    assert git.get_tags() == []
+
+
+def test_get_tag_names(mocker):
+    tag_str = "v1.0.0\n" "v0.5.0\n" "v0.0.1\n"
+    mocker.patch("commitizen.cmd.run", return_value=FakeCommand(out=tag_str))
+
+    assert git.get_tag_names() == ["v1.0.0", "v0.5.0", "v0.0.1"]
+
+    mocker.patch(
+        "commitizen.cmd.run", return_value=FakeCommand(out="", err="No tag available")
+    )
+    assert git.get_tag_names() == []

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,11 @@
+from commitizen import git
+
+
+def test_git_object_eq():
+    git_commit = git.GitCommit(
+        rev="sha1-code", title="this is title", body="this is body"
+    )
+    git_tag = git.GitTag(rev="sha1-code", name="0.0.1", date="2020-01-21")
+
+    assert git_commit == git_tag
+    assert git_commit != "sha1-code"


### PR DESCRIPTION

* modify the way `commitizen.cmd` interact with shell
    * the original design fails to handle `git tag` with long arguments
* use `GitObject` (`GitTag`, `GitCommit`) classes to store git information
    * add get git tags, commits functions
* rename variables
* add test cases and reorganize existing test cases

I start working on changelog (#53) on my [changelog](https://github.com/Lee-W/commitizen/tree/changelog) branch and have a prototype of it.
However, the pull request will be too huge to review if I send it after I finish all the functionality.
Thus, I separate the changelog related commits and other refactor commits which are changed as a preparation for the new functionality.
This PR is for the refactor ones.
