### PR TITLE
Set pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,6 @@
   entry: cz check --commit-msg-file
   language: python
   language_version: python3
+  stages: [commit-msg]
   require_serial: true
   minimum_pre_commit_version: "0.15.4"

--- a/docs/check.md
+++ b/docs/check.md
@@ -15,7 +15,7 @@ python -m pip install pre-commit
 
 ```yaml
 - repo: https://github.com/Woile/commitizen
-  rev: 1.13.1
+  rev: master
   hooks:
     - id: commitizen
 ```


### PR DESCRIPTION
Since `cz check` is needed only when committing, I set pre-commit check stage to commit-msg.
