### PR TITLE
[Fix] add "bump" into valid commit message in conventional commit

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -171,7 +171,7 @@ class ConventionalCommitsCz(BaseCommitizen):
 
     def schema_pattern(self) -> str:
         PATTERN = (
-            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)"
+            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"
             r"(\([\w\-]+\))?:\s.*"
         )
         return PATTERN

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -93,11 +93,19 @@ def test_check_no_conventional_commit(config, mocker, tmpdir):
         error_mock.assert_called_once()
 
 
-def test_check_conventional_commit(config, mocker, tmpdir):
+@pytest.mark.parametrize(
+    "commit_msg",
+    (
+        "feat(lang): added polish language",
+        "feat: add polish language",
+        "bump: 0.0.1 -> 1.0.0",
+    ),
+)
+def test_check_conventional_commit(commit_msg, config, mocker, tmpdir):
     success_mock = mocker.patch("commitizen.out.success")
 
     tempfile = tmpdir.join("temp_commit_file")
-    tempfile.write("feat(lang): added polish language")
+    tempfile.write(commit_msg)
 
     check_cmd = commands.Check(config=config, arguments={"commit_msg_file": tempfile})
 


### PR DESCRIPTION
Currently, if `cz check` is enforced, it bloack `cz bump`