### PR TITLE
Fix pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,5 @@
   entry: cz check --commit-msg-file
   language: python
   language_version: python3
-  stages: [commit-msg]
   require_serial: true
   minimum_pre_commit_version: "0.15.4"

--- a/docs/check.md
+++ b/docs/check.md
@@ -16,6 +16,7 @@ python -m pip install pre-commit
 ```yaml
 - repo: https://github.com/Woile/commitizen
   rev: master
+  stages: [commit-msg]
   hooks:
     - id: commitizen
 ```


### PR DESCRIPTION
In the previous pre-commit PR, I add the wrong `stages` argument into the `.pre-commit-hooks.yaml`. It should be defined on the user side. I'll also update the document.

BTW, I notice it didn't bump the version and release on the previous PR.